### PR TITLE
Add: build-essential

### DIFF
--- a/validator.md
+++ b/validator.md
@@ -9,7 +9,7 @@ Install Node and dev dependencies:
 sudo apt update
 curl -sL https://deb.nodesource.com/setup_14.x | sudo bash -
 sudo apt -y install nodejs
-sudo apt -y install gcc g++ make git
+sudo apt -y install gcc g++ make git build-essential
 ```
 
 Install the [PM2 npm package](https://pm2.keymetrics.io/), a daemon process manager:


### PR DESCRIPTION
You need to add 'build-essential' to the system before you can perform the npm install of pm2.